### PR TITLE
Multiple file and Run all support

### DIFF
--- a/guard-coffeelint.gemspec
+++ b/guard-coffeelint.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'guard', '~> 2.0'
-  # spec.add_dependency 'coffeelint', '~> 1.0'
+  spec.add_dependency 'colorize'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/guard-coffeelint.gemspec
+++ b/guard-coffeelint.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'guard', '~> 2.12.4'
-  spec.add_dependency 'coffeelint', '~> 1.9.1'
+  spec.add_dependency 'guard', '~> 2.0'
+  # spec.add_dependency 'coffeelint', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -15,15 +15,14 @@ module Guard
       UI.info "Guard::Coffeelint linting against #{@config_file}"
     end
 
-    # Default behaviour on file(s) changes that the Guard plugin watches.
-    # @param [Array<String>] paths the changes files or paths
-    # @raise [:task_has_failed] when run_on_change has failed
-    # @return [Object] the task result
-    #
-    def run_on_changes(paths)
+    def run_on_additions(paths)
       lint_and_report paths
     end
 
+    def run_on_modifications(paths)
+      lint_and_report paths
+    end
+    
     def run_all
       lint_and_report
     end
@@ -50,7 +49,7 @@ module Guard
                    ' .'
                  end
 
-      results = `#{command}`
+      results = `#{command} 2>&1`
 
       begin
         results = JSON.parse(results)

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -68,7 +68,7 @@ module Guard
                          end
 
           puts "#{file.cyan}:#{error['lineNumber']}:#{error_letter}" \
-            ": #{error['name']}: #{error['message']}.#{error['context']}"
+            ": #{error['name']}: #{error['message']}. #{error['context']}"
         end
       end
 

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -36,7 +36,7 @@ module Guard
       else
         :success
       end
-      Notifier.notify(msg, title: "Coffeelint", image: image)
+      Notifier.notify(msg, title: "CoffeeLint", image: image)
     end
 
 

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -1,14 +1,16 @@
-
 require 'guard'
 require 'guard/plugin'
-require 'coffeelint'
+require 'JSON'
+require 'colorize'
+# require 'coffeelint'
 
 module Guard
   class Coffeelint < Plugin
 
     def initialize(options = {})
       super
-      @config_file = options[:config_file] || 'config/coffeelint.json'
+      # @config_file = options[:config_file] || 'config/coffeelint.json'
+      @config_file = options[:config_file]
     end
 
     def start
@@ -21,28 +23,29 @@ module Guard
     # @return [Object] the task result
     #
     def run_on_changes(paths)
+      lint_and_report paths
       # Total errors across all files
-      error_count = 0
+      # error_count = 0
 
-      paths.each do |path|
-        errors = lint_and_report(path)
+      # paths.each do |path|
+      #   errors = lint_and_report(path)
 
-        error_count += errors.length
-      end
+      #   error_count += errors.length
+      # end
 
-      notify(paths, error_count)
+      # notify(paths, error_count)
 
-      true
+      # true
+    end
+
+    def run_all
+      lint_and_report
     end
 
     protected
 
-    def notify(paths, error_count)
-      message = if paths.length == 1
-        "#{error_count} errors in #{paths[0]}"
-      else
-        "#{error_count} errors in #{paths.length} files"
-      end
+    def notify(file_count, error_count)
+      message =  "#{error_count} errors in #{file_count} files"
 
       image = if error_count > 0
         :failed
@@ -50,28 +53,85 @@ module Guard
         :success
       end
 
-      Notifier.notify(message, title: "Coffeelint", image: image)
+      summary = "#{file_count} files scanned, "
+      summary << if error_count > 0
+                   "#{error_count} errors"
+                 else
+                   "No errors"
+                 end
+      summary << " found."
+
+      Notifier.notify(summary, title: "Coffeelint", image: image)
     end
 
 
-    def lint_and_report(path)
+    def lint_and_report(paths = nil)
       # This is reporting some bad false-positives
-      #errors = ::Coffeelint.lint_file(path, config_file: @config_file)
+      # errors = ::Coffeelint.lint_file(path, config_file: @config_file)
 
       # This works :|
-      errors = JSON.parse(`coffeelint --reporter raw -f #{@config_file} #{path}`).values.first
+      command = 'coffeelint -c --reporter raw'
+      command += "-f #{@config_file}" if @config_file
+      command += if paths && paths.length > 0
+                   " #{paths.join ' '}"
+                 else
+                   ' .'
+                 end
 
-      if errors.length > 0
-        UI.warning "Coffeelint: #{path} has #{errors.length} errors"
+      puts command
+      results = `#{command}`
+      puts results
+      puts $?.success?
 
-        errors.each do |error|
-          UI.warning "#{error['lineNumber']}: #{error['message']} (#{error['context']})"
-        end
-
+      begin
+        results = JSON.parse(results)
+      rescue JSON::ParserError
+        UI.error "Error linting #{paths}"
+        return
       end
 
-      errors
-    end
+      results.each do |file, errors|
+        errors.each do |error|
+          error_letter = error['level'].chars.first.upcase
+          error_letter = case error_letter
+                         when 'E' then error_letter.red
+                         when 'W' then error_letter.yellow
+                         else error_letter
+                         end
 
+          puts "#{file.cyan}:#{error['lineNumber']}:#{error_letter}" \
+            ": #{error['name']}: #{error['message']}.#{error['context']}"
+        end
+      end
+
+      file_count = results.size
+      error_count = results.map { |_, e| e.size }.reduce(:+)
+      summary = "#{file_count} files scanned, "
+      summary << if error_count > 0
+                   "#{error_count} errors".red
+                 else
+                   "No errors".green
+                 end
+      summary << " found."
+
+      puts "\n" + summary
+
+      notify file_count, error_count
+
+      throw :task_has_failed unless error_count == 0
+
+      # errors = JSON.parse(`coffeelint --reporter raw -f #{@config_file} #{path}`).values.first
+
+    #   if errors.length > 0
+    #     UI.warning "Coffeelint: #{path} has #{errors.length} errors"
+
+    #     errors.each do |error|
+    #       UI.warning "#{error['lineNumber']}: #{error['message']} (#{error['context']})"
+    #     end
+
+    #   end
+
+    #   errors
+    end
   end
 end


### PR DESCRIPTION
This is a relatively large rework of the guard, so I don't know if you will like all of my changes, but I wanted to open up this pull request to start a dialogue.  

My main motivation was to allow `run_all` to behave properly.  We use Guard extensively and for developers, the main way to run all checks on our code base (tests, stylechecks, test coverage, etc) is to hit enter (run all) in the guard console.  guard-coffeelint didn't support this, so I decided to add it.  

Along with that, there is a custom reporter that handles the output well.  

Let me know what you think.  If there are parts you like and parts you don't, I'm open to slicing and dicing this up to get the best of both worlds.