### PR TITLE
Fix require 'json'

### DIFF
--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -1,6 +1,6 @@
 require 'guard'
 require 'guard/plugin'
-require 'JSON'
+require 'json'
 require 'colorize'
 
 module Guard


### PR DESCRIPTION
In CI (which is ubuntu) I had an issue with the `require 'JSON'` as it is case-sensitive. This modifies to `require 'json'` instead so that it works on linux. I fixed CI by doing `gem 'guard-coffeelint', require: false` anyway, but thought I'd send this tiny PR.