### PR TITLE
Default to config/coffeelint.json as defined in README

### DIFF
--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -8,7 +8,7 @@ module Guard
 
     def initialize(options = {})
       super
-      @config_file = options[:config_file]
+      @config_file = options[:config_file] || 'config/coffeelint.json'
     end
 
     def start


### PR DESCRIPTION
The `coffeescript` command defaults to using `coffeelint.json` instead of `config/coffeelint.json`, so we need to manually define it as a default parameter to match the README's default config file.