### PR TITLE
Add the ability to pass paths to coffeelint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ If this doesn't work for you, use
   end
   ```
 
+### Configuration options
+
+You can pass some options in `Guardfile` like the following example:
+
+```ruby
+guard :coffeelint, config_file: 'config/coffeelint.json', paths: %w(app/assets/javascripts) do
+  # ...
+end
+```
+
+#### Available Options
+
+```ruby
+config_file: 'config/coffeelint.json' # Change the config file loaded
+                                      #   default: 'coffeelint.json'
+
+paths: %w(app/assets/javascripts)     # An array of paths passed to coffeelint to look for
+                                      # coffeescript files.
+                                      #   default: '.'
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -9,6 +9,7 @@ module Guard
     def initialize(options = {})
       super
       @config_file = options[:config_file]
+      @default_paths = options[:paths] || ['.']
     end
 
     def start
@@ -22,7 +23,7 @@ module Guard
     def run_on_modifications(paths)
       lint_and_report paths
     end
-    
+
     def run_all
       lint_and_report
     end
@@ -46,7 +47,7 @@ module Guard
       command += if paths && paths.length > 0
                    " #{paths.join ' '}"
                  else
-                   ' .'
+                   " #{@default_paths.join(' ')}"
                  end
 
       results = `#{command} 2>&1`


### PR DESCRIPTION
Adds a `paths` config option to the Guardfile so that specific directories to lint can be specified as described in #15