### PR TITLE
Remove GPL - replace colorize with rainbow gem

### DIFF
--- a/guard-coffeelint.gemspec
+++ b/guard-coffeelint.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'guard', '~> 2.0'
-  spec.add_dependency 'colorize', '~> 0.7'
+  spec.add_dependency 'rainbow', '~> 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -1,10 +1,11 @@
 require 'guard'
 require 'guard/plugin'
 require 'json'
-require 'colorize'
+require 'rainbow/refinement'
 
 module Guard
   class Coffeelint < Plugin
+    using Rainbow
 
     def initialize(options = {})
       super

--- a/lib/guard/coffeelint.rb
+++ b/lib/guard/coffeelint.rb
@@ -1,11 +1,10 @@
 require 'guard'
 require 'guard/plugin'
 require 'json'
-require 'rainbow/refinement'
+require 'rainbow'
 
 module Guard
   class Coffeelint < Plugin
-    using Rainbow
 
     def initialize(options = {})
       super
@@ -64,8 +63,8 @@ module Guard
         errors.each do |error|
           error_letter = error['level'].chars.first.upcase
           error_letter = case error_letter
-                         when 'E' then error_letter.red
-                         when 'W' then error_letter.yellow
+                         when 'E' then Rainbow(error_letter).red
+                         when 'W' then Rainbow(error_letter).yellow
                          else error_letter
                          end
 
@@ -87,10 +86,10 @@ module Guard
       summary = "#{file_count} files scanned, "
       summary << if error_count > 0
                    s = "#{error_count} errors"
-                   color ? s.red : s
+                   color ? Rainbow(s).red : s
                  else
                    s = "No errors"
-                   color ? s.green : s
+                   color ? Rainbow(s).green : s
                  end
       summary << " found."
     end


### PR DESCRIPTION
The currently used `colorize` gem is released under the GPL license which is incompatible with this library's MIT license.  Swap that one out for the `rainbow` gem, which is released under the MIT license.
